### PR TITLE
fix: do not close logger fd on exit

### DIFF
--- a/src/runtime/module.c
+++ b/src/runtime/module.c
@@ -167,11 +167,6 @@ lotto_exit(capture_point *cp, reason_t reason)
 static void DICE_DTOR
 runtime_fini_(void)
 {
-    if (_logger_fd >= 0) {
-        close(_logger_fd);
-        _logger_fd = -1;
-    }
-
     capture_point cp = {
         .chain_id = 0,
         .type_id  = EVENT_TASK_FINI,


### PR DESCRIPTION
- logger.c does not use `_logger_fd`. After closing it, logger is still writing to it.
- dice log catches the error and fail directly.
- (due to a dice logger problem, it can cause infinite recursion and segfault)

This can be reproduced by
```
$ lotto stress ./modules/inflex/test/inflex_abc 
$ lotto replay -g 0 --log /tmp/log -vvv
Signal Segmentation fault received
```

The simpler fix is just to keep the fd open.