### PR TITLE
busyabort: split busy-loop abort policy out of watchdog

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -52,6 +52,7 @@ add_module(filtering)
 # feature handlers
 add_module(available)
 add_module(watchdog)
+add_module(busyabort DEFAULT OFF)
 add_module(ichpt)
 add_module(race)
 add_module(atomic)

--- a/modules/busyabort/CMakeLists.txt
+++ b/modules/busyabort/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(src)

--- a/modules/busyabort/src/CMakeLists.txt
+++ b/modules/busyabort/src/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_runtime_module(state.c handler.c module.c)
+add_driver_module(state.c flags.c module.c)

--- a/modules/busyabort/src/flags.c
+++ b/modules/busyabort/src/flags.c
@@ -1,0 +1,13 @@
+#include "state.h"
+#include <lotto/base/flags.h>
+#include <lotto/driver/flagmgr.h>
+
+NEW_PRETTY_CALLBACK_FLAG(HANDLER_BUSYABORT_ENABLED, "", "handler-busyabort",
+                         "enable busy-loop abort handler", flag_on(),
+                         STR_CONVERTER_BOOL,
+                         { busyabort_config()->enabled = is_on(v); })
+
+NEW_CALLBACK_FLAG(BUSYABORT_THRESHOLD, "", "busyabort-threshold", "",
+                  "repeat count threshold before abort, 0 for never",
+                  flag_uval(~0ULL),
+                  { busyabort_config()->threshold = as_uval(v); })

--- a/modules/busyabort/src/handler.c
+++ b/modules/busyabort/src/handler.c
@@ -1,0 +1,56 @@
+#include "state.h"
+#include <dice/events/memaccess.h>
+#include <lotto/engine/pubsub.h>
+#include <lotto/engine/sequencer.h>
+#include <lotto/engine/statemgr.h>
+#include <lotto/sys/assert.h>
+#include <lotto/sys/logger.h>
+
+/*
+ * Abort when the same task repeats the same memaccess event at the same pc
+ * for too long, which usually indicates a stuck busy-loop.
+ */
+typedef struct {
+    task_id last_tid;
+    type_id last_type_id;
+    uintptr_t last_pc;
+    uint64_t repeat_count;
+} busy_state_t;
+
+static busy_state_t _state;
+
+STATIC void
+_busyabort_handle(const capture_point *cp, event_t *e)
+{
+    (void)e;
+    ASSERT(cp != NULL);
+
+    if (!busyabort_config()->enabled) {
+        return;
+    }
+    if (!is_memaccess(cp->type_id)) {
+        return;
+    }
+    if (busyabort_config()->threshold == 0) {
+        return;
+    }
+
+    if (_state.last_tid == cp->id && _state.last_type_id == cp->type_id &&
+        _state.last_pc == cp->pc) {
+        _state.repeat_count++;
+    } else {
+        _state.last_tid     = cp->id;
+        _state.last_type_id = cp->type_id;
+        _state.last_pc      = cp->pc;
+        _state.repeat_count = 1;
+    }
+
+    if (_state.repeat_count < busyabort_config()->threshold) {
+        return;
+    }
+
+    logger_fatalf(
+        "[tid: %lu, type: %s, pc: %p, count: %lu] stuck at busyloop\n", cp->id,
+        ps_type_str(cp->type_id), (void *)cp->pc, _state.repeat_count);
+}
+ON_SEQUENCER_CAPTURE(_busyabort_handle)

--- a/modules/busyabort/src/module.c
+++ b/modules/busyabort/src/module.c
@@ -1,0 +1,3 @@
+#include <lotto/engine/pubsub.h>
+
+LOTTO_MODULE_INIT()

--- a/modules/busyabort/src/state.c
+++ b/modules/busyabort/src/state.c
@@ -1,0 +1,15 @@
+#include "state.h"
+#include <lotto/engine/statemgr.h>
+
+static busyabort_config_t _config;
+
+REGISTER_CONFIG(_config, {
+    _config.enabled   = true;
+    _config.threshold = ~0ULL;
+})
+
+busyabort_config_t *
+busyabort_config(void)
+{
+    return &_config;
+}

--- a/modules/busyabort/src/state.h
+++ b/modules/busyabort/src/state.h
@@ -1,0 +1,17 @@
+#ifndef LOTTO_BUSYABORT_STATE_H
+#define LOTTO_BUSYABORT_STATE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <lotto/base/marshable.h>
+
+typedef struct busyabort_config {
+    marshable_t m;
+    bool enabled;
+    uint64_t threshold;
+} busyabort_config_t;
+
+busyabort_config_t *busyabort_config(void);
+
+#endif

--- a/modules/watchdog/src/handler.c
+++ b/modules/watchdog/src/handler.c
@@ -24,16 +24,10 @@ typedef struct {
     task_id id;
     nanosec_t ts;
     clk_t ticks;
-    task_id last_tid;
-    type_id last_type_id;
-    uintptr_t last_pc;
-    uint64_t repeat_count;
 } state_t;
 static state_t _state;
 
 REGISTER_EPHEMERAL(_state, ({ _state = (state_t){0}; }))
-
-#define BUSYEVER_THRESHOLD 1000
 
 static void
 _watchdog_reset(task_id id)
@@ -41,30 +35,6 @@ _watchdog_reset(task_id id)
     _state.id = id;
     _state.ticks =
         prng_range(watchdog_config()->budget / 2, watchdog_config()->budget);
-}
-
-static void
-_watchdog_track_busyever(const capture_point *cp)
-{
-    if (!is_memaccess(cp->type_id))
-        return;
-    if (_state.last_tid == cp->id && _state.last_type_id == cp->type_id &&
-        _state.last_pc == cp->pc) {
-        _state.repeat_count++;
-    } else {
-        _state.last_tid     = cp->id;
-        _state.last_type_id = cp->type_id;
-        _state.last_pc      = cp->pc;
-        _state.repeat_count = 1;
-    }
-
-    if (_state.repeat_count < BUSYEVER_THRESHOLD) {
-        return;
-    }
-
-    logger_fatalf(
-        "[tid: %lu, type: %s, pc: %p, count: %lu] stuck at busyloop\n", cp->id,
-        ps_type_str(cp->type_id), (void *)cp->pc, _state.repeat_count);
 }
 
 static bool
@@ -93,8 +63,6 @@ _watchdog_handle(const capture_point *cp, event_t *e)
     ASSERT(e);
     if (!watchdog_config()->enabled)
         return;
-
-    _watchdog_track_busyever(cp);
 
     if (e->skip)
         return;


### PR DESCRIPTION
Move the fatal busy-loop repeat detector into a separate module (busyabort) and keep watchdog focused on budget-based rescheduling.

Adds busyabort runtime/driver module with flags and removes busy-loop abort tracking from watchdog handler.