### PR TITLE
Adds loop detection and reduced memory accesses to be able to boot linux

### DIFF
--- a/modules/qemu/include/lotto/modules/qemu/util.h
+++ b/modules/qemu/include/lotto/modules/qemu/util.h
@@ -20,6 +20,7 @@ void vcpu_mem_capture(unsigned int cpu_index, qemu_plugin_meminfo_t info,
 void vcpu_insn_capture(unsigned int cpu_index, void *udata);
 void vcpu_loop_capture(unsigned int cpu_index, void *udata);
 void vcpu_event_capture(unsigned int cpu_index, void *udata);
+void emit_loop(unsigned int cpu_index, void *udata);
 void emit_udf_trap(unsigned int cpu_index, void *udata);
 void emit_wfe(unsigned int cpu_index, void *udata);
 void emit_wfi(unsigned int cpu_index, void *udata);
@@ -45,6 +46,13 @@ static inline void
 bind_wfi_callback(struct qemu_plugin_insn *insn)
 {
     qemu_plugin_register_vcpu_insn_exec_cb(insn, emit_wfi,
+                                           QEMU_PLUGIN_CB_NO_REGS, NULL);
+}
+
+static inline void
+bind_branch_callback(struct qemu_plugin_insn *insn)
+{
+    qemu_plugin_register_vcpu_insn_exec_cb(insn, emit_loop,
                                            QEMU_PLUGIN_CB_NO_REGS, NULL);
 }
 

--- a/modules/qemu/src/CMakeLists.txt
+++ b/modules/qemu/src/CMakeLists.txt
@@ -4,6 +4,7 @@ add_runtime_module(
     translate_aarch64.c
     interceptors.c
     emit_cpu_context.c
+    emit_loop.c
     emit_memaccess.c
     emit_udf_trap.c
     emit_wfe.c

--- a/modules/qemu/src/emit_loop.c
+++ b/modules/qemu/src/emit_loop.c
@@ -1,0 +1,22 @@
+#include "interceptors.h"
+#include <lotto/modules/qemu/util.h>
+#include <lotto/yield.h>
+#include <stdio.h>
+
+uint64_t branch_back_count = 0;
+
+void
+emit_loop(unsigned int cpu_index, void *udata)
+{
+    uint64_t reduction = 1000; // 100000
+
+    (void)udata;
+    if (!qemu_instrumentation_enabled(cpu_index)) {
+        return;
+    }
+
+    if (branch_back_count % reduction == 0) {
+        lotto_yield(true);
+    }
+    branch_back_count++;
+}

--- a/modules/qemu/src/emit_loop.c
+++ b/modules/qemu/src/emit_loop.c
@@ -1,22 +1,21 @@
 #include "interceptors.h"
 #include <lotto/modules/qemu/util.h>
 #include <lotto/yield.h>
-#include <stdio.h>
 
 uint64_t branch_back_count = 0;
 
 void
 emit_loop(unsigned int cpu_index, void *udata)
 {
-    uint64_t reduction = 1000; // 100000
+    uint64_t reduction = 1000;
 
     (void)udata;
     if (!qemu_instrumentation_enabled(cpu_index)) {
         return;
     }
 
+    branch_back_count++;
     if (branch_back_count % reduction == 0) {
         lotto_yield(true);
     }
-    branch_back_count++;
 }

--- a/modules/qemu/src/emit_memaccess.c
+++ b/modules/qemu/src/emit_memaccess.c
@@ -7,6 +7,8 @@
 #include <lotto/engine/pubsub.h>
 #include <lotto/modules/qemu/util.h>
 
+uint64_t mem_access_counter = 0;
+
 static inline uint64_t
 qemu_memaccess_size(qemu_plugin_meminfo_t info)
 {
@@ -96,6 +98,12 @@ emit_memaccess(unsigned int cpu_index, qemu_plugin_meminfo_t info,
     if (!qemu_instrumentation_enabled(cpu_index)) {
         return;
     }
+
+    uint64_t reduction = 1000; // 100000
+    mem_access_counter++;
+
+    if(mem_access_counter % reduction != 0)
+        return;
 
     bool atomic_like = ((uintptr_t)udata) != 0;
     capture_point cp = {.chain_id = INTERCEPT_EVENT, .func = __FUNCTION__};

--- a/modules/qemu/src/translate_aarch64.c
+++ b/modules/qemu/src/translate_aarch64.c
@@ -2,7 +2,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-#include "qemu-plugin.h"
 #include "translate_aarch64.h"
 #include "interceptors.h"
 #include <dice/chains/intercept.h>
@@ -144,13 +143,10 @@ loop_check(struct qemu_plugin_insn *insn, cs_insn *insn_cs, uint32_t opcode, uin
     int64_t b_insn_diff = 0;
     int32_t opnum = insn_cs->detail->arm64.op_count-1;
 
-    // ASSERT(opcount == insn_cs->detail->arm64.op_count);
     ASSERT(ARM64_OP_IMM == insn_cs->detail->arm64.operands[opnum].type);
 
     b_insn_diff =
         (insn_cs->detail->arm64.operands[opnum].imm - (int64_t)pc) / 4;
-
-    // fprintf(stderr, "loop check found: %ld.\n", b_insn_diff);
 
     if (b_insn_diff <= 0) {
         bind_branch_callback(insn);

--- a/modules/qemu/src/translate_aarch64.c
+++ b/modules/qemu/src/translate_aarch64.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "qemu-plugin.h"
 #include "translate_aarch64.h"
 #include "interceptors.h"
 #include <dice/chains/intercept.h>
@@ -12,17 +13,23 @@
 #include <lotto/runtime/capture_point.h>
 #include <lotto/sys/stdlib.h>
 
+#include <capstone/arm64.h>
+#include <capstone/capstone.h>
+
 #define AARCH64_WFE_OPCODE 0xd503205fU
 #define AARCH64_WFI_OPCODE 0xd503207fU
 
 static icounter_t g_inline_insn_count;
 static bool g_inline_insn_count_initialized = false;
+static csh disasm;
+
 
 typedef struct qemu_translation_policy {
     bool memaccess;
     bool udf;
     bool yield;
     bool wf;
+    bool branch;
 } qemu_translation_policy_t;
 
 static bool
@@ -47,6 +54,7 @@ translation_policy(void)
             .udf       = env_enabled("LOTTO_QEMU_INSTR_UDF", true),
             .yield     = env_enabled("LOTTO_QEMU_INSTR_YIELD", true),
             .wf        = env_enabled("LOTTO_QEMU_INSTR_WF", true),
+            .branch    = env_enabled("LOTTO_QEMU_INSTR_BRANCH", true),
         };
         initialized = true;
     }
@@ -130,6 +138,58 @@ bind_wf_instruction(struct qemu_plugin_insn *insn, uint32_t opcode,
     }
 }
 
+void
+loop_check(struct qemu_plugin_insn *insn, cs_insn *insn_cs, uint32_t opcode, uint64_t pc)
+{
+    int64_t b_insn_diff = 0;
+    int32_t opnum = insn_cs->detail->arm64.op_count-1;
+
+    // ASSERT(opcount == insn_cs->detail->arm64.op_count);
+    ASSERT(ARM64_OP_IMM == insn_cs->detail->arm64.operands[opnum].type);
+
+    b_insn_diff =
+        (insn_cs->detail->arm64.operands[opnum].imm - (int64_t)pc) / 4;
+
+    // fprintf(stderr, "loop check found: %ld.\n", b_insn_diff);
+
+    if (b_insn_diff <= 0) {
+        bind_branch_callback(insn);
+    }
+}
+
+static void
+bind_branch_instruction(struct qemu_plugin_insn *insn, uint32_t opcode,
+                    const qemu_translation_policy_t *policy)
+{
+    if (!policy->branch) {
+        return;
+    }
+
+    uint64_t pc = qemu_plugin_insn_vaddr(insn);
+    cs_insn *insn_cs;
+
+    if (cs_disasm(disasm, (const unsigned char *)&opcode, sizeof(opcode),
+            pc, 0, &insn_cs) == 1) {
+
+        switch (insn_cs->id) {
+        case ARM64_INS_CBZ:
+        case ARM64_INS_CBNZ:
+        case ARM64_INS_TBL:
+        case ARM64_INS_TBNZ:
+        case ARM64_INS_TBX:
+        case ARM64_INS_TBZ:
+        case ARM64_INS_B:
+        case ARM64_INS_BC:
+            loop_check(insn, insn_cs, opcode, pc);
+            break;
+        default:
+            break;
+        }
+    }
+
+    return;
+}
+
 static void
 decode_and_bind_insn(struct qemu_plugin_insn *insn,
                      const qemu_translation_policy_t *policy)
@@ -149,6 +209,7 @@ decode_and_bind_insn(struct qemu_plugin_insn *insn,
 
     bind_wf_instruction(insn, opcode, policy);
     bind_udf_instruction(insn, opcode, policy);
+    bind_branch_instruction(insn, opcode, policy);
 }
 
 void
@@ -186,6 +247,10 @@ qemu_on_plugin_start(qemu_plugin_id_t id, const qemu_info_t *info, int argc,
     (void)argv;
     icounter_init(&g_inline_insn_count);
     g_inline_insn_count_initialized = true;
+
+    cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &disasm);
+    cs_option(disasm, CS_OPT_DETAIL, CS_OPT_ON);
+
     qemu_emit_start();
 }
 

--- a/scripts/qlotto-linux.sh
+++ b/scripts/qlotto-linux.sh
@@ -99,7 +99,7 @@ if [[ -n "$SNAPSHOT_DRIVE" ]]; then
     QEMU_ARGS+=("-drive" "file=$SNAPSHOT_DRIVE,if=virtio,format=qcow2")
 fi
 
-exec "$LOTTO" stress -Q "${LOTTO_ARGS[@]}" -- \
+exec "$LOTTO" stress -Q --clock-mult-inc 1000 "${LOTTO_ARGS[@]}" -- \
     -kernel "$KERNEL" \
     -initrd "$INITRD" \
     "${QEMU_ARGS[@]}" \


### PR DESCRIPTION
Brings back capstone usage to decode branch instructions for loop detection.
Reduces lotto events for memory access and loop yield to 1/1000.
Sets clock multiplier to 1000 for qlotto-linux example.